### PR TITLE
Fix library path detection.

### DIFF
--- a/plugin/gvim_fullscreen.vim
+++ b/plugin/gvim_fullscreen.vim
@@ -4,17 +4,20 @@ function! ToggleFullscreen()
     endif
 endfunction
 
-function! s:dll_is_installed(lib_path)
-    let dll_installed = len(split(globpath(&rtp, a:lib_path), '\n'))
-    return dll_installed && 1
+function! s:get_lib_path()
+    if has('win64')
+        let lib_path = 'lib\x64\gvimfullscreen_64.dll'
+    elseif has('win32')
+        let lib_path = 'lib\x86\gvimfullscreen.dll'
+    else
+        return ''
+    endif
+    return get(globpath(&rtp, lib_path, 0, 1), 0, '')
 endfunction
 
 function! s:toggle_fullscreen()
-    if has("win32")
-        let lib_path = "lib\x86\gvimfullscreen.dll"
-        if s:dll_is_installed(lib_path)
-            let $GVIM_FULLSCREEN_DLL_PATH = split(globpath(&rtp, lib_path))[0]
-            call libcallnr($GVIM_FULLSCREEN_DLL_PATH, "ToggleFullScreen", 0)
-        endif
+    let lib_path = s:get_lib_path()
+    if !empty(lib_path)
+        call libcallnr(lib_path, "ToggleFullScreen", 0)
     endif
 endfunction


### PR DESCRIPTION
* Check `has('win64')` and change path.
* Using `globpath()` result as list. (Error is occurred when path contains spaces.)